### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Manage the database in administration
 
 ## Install with composer
 * Change to your root Installation of shopware
-* Run command `composer require frosh/adminer-platform` and install and active plugin with Plugin Manager 
+* Run command `composer require frosh/adminer-platform:dev-master` and install and active plugin with Plugin Manager 


### PR DESCRIPTION
The last official release is not compatible with Shopware 6.3, so to install the plugin with composer one has to download the `dev-master` version. Or alternatively please make a new release.