### PR TITLE
Global showare object instead of core

### DIFF
--- a/src/Resources/app/administration/src/core/service/api/adminer.service.js
+++ b/src/Resources/app/administration/src/core/service/api/adminer.service.js
@@ -1,4 +1,4 @@
-const ApiService = Shopware.Classes.ApiService;
+const { ApiService } = Shopware;
 
 class AdminerService extends ApiService {
     constructor(httpClient, loginService, apiEndpoint = 'frosh_adminer') {


### PR DESCRIPTION
Used the global Shopware import for Api Service rather than using imports directly from the Shopware Core via "/src/core/service/api.service"  Shopware version: 6.4.6.0