### PR TITLE
Support DATABASE_SSL_* env-variables

### DIFF
--- a/src/Adminer/index.php
+++ b/src/Adminer/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+
 function adminer_object()
 {
     include_once  __DIR__ . '/plugin.php';
@@ -12,7 +14,19 @@ function adminer_object()
         new AdminerFrames(true),
         new AdminerTablesFilter(),
         new AdminerLoginPasswordLess(),
+        new AdminerLoginSsl(adminer_ssl_configuration()),
     ]);
+}
+
+function adminer_ssl_configuration()
+{
+    $ssl = [
+        'ca' => EnvironmentHelper::getVariable('DATABASE_SSL_CA'),
+        'cert' => EnvironmentHelper::getVariable('DATABASE_SSL_CERT'),
+        'key' => EnvironmentHelper::getVariable('DATABASE_SSL_KEY'),
+    ];
+
+    return 0 < count(array_filter($ssl)) ? $ssl : null;
 }
 
 error_reporting(0);

--- a/src/Adminer/plugins/AdminerLoginSsl.php
+++ b/src/Adminer/plugins/AdminerLoginSsl.php
@@ -1,0 +1,24 @@
+<?php
+
+/** Connect to MySQL using SSL
+* @link https://www.adminer.org/plugins/#use
+* @author Jakub Vrana, https://www.vrana.cz/
+* @license https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+* @license https://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 (one or other)
+*/
+class AdminerLoginSsl {
+	/** @access protected */
+	var $ssl;
+
+	/**
+	* @param array array("key" => filename, "cert" => filename, "ca" => filename)
+	*/
+	function __construct($ssl) {
+		$this->ssl = $ssl;
+	}
+
+	function connectSsl() {
+		return $this->ssl;
+	}
+
+}


### PR DESCRIPTION
Add Adminer plugin to support database servers requiring SSL.

The env-variables are also used by Shopware:
https://github.com/shopware/core/blob/v6.6.3.1/Framework/Adapter/Database/MySQLFactory.php