### PR TITLE
fix: require authenticated session before loading Adminer UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "frosh/adminer-platform",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "type": "shopware-platform-plugin",
     "keywords": ["adminer", "shopware", "frosh"],
     "description": "Adminer for Shopware",

--- a/src/Controller/AdminerController.php
+++ b/src/Controller/AdminerController.php
@@ -25,6 +25,7 @@ class AdminerController extends AbstractController
 
         header_remove('Set-Cookie');
         $_SESSION["token"] = rand(1, 1e6);
+        $_SESSION['frosh_adminer_authenticated'] = true;
 
         $_SESSION["dbs"]['server'][$credentials['host']][$credentials['user']] = [
             $credentials['path']
@@ -51,7 +52,15 @@ class AdminerController extends AbstractController
     #[Route(path: '/%shopware_administration.path_name%/adminer', name: 'administration.frosh_adminer', defaults: ['auth_required' => false, '_routeScope' => ['administration']], methods: ['GET', 'POST'])]
     public function index(): Response
     {
-        chdir(__DIR__ . '/../Adminer');;
+        session_cache_limiter('');
+        session_name('adminer_sid');
+        session_start();
+
+        if (empty($_SESSION['frosh_adminer_authenticated'])) {
+            return new Response('Forbidden', Response::HTTP_FORBIDDEN);
+        }
+
+        chdir(__DIR__ . '/../Adminer');
         unset($_POST['auth']);
         require __DIR__ . '/../Adminer/Adminer.php';
         return new Response('');


### PR DESCRIPTION
The /admin/adminer route had auth_required=false and no session validation, making the Adminer UI accessible to anyone who knows the URL without prior admin authentication.

This adds a session-based check: the login() endpoint now sets a frosh_adminer_authenticated flag in the session, and index() verifies this flag before loading Adminer — returning 403 Forbidden otherwise.

Closes FriendsOfShopware/FroshPlatformAdminer#31

Increase version