### PR TITLE
docs: add GitHub security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Important Notice
+
+This plugin provides **direct database access** through the Shopware Administration and is intended for **development environments only**. Do not use it in production.
+
+Ensure that only trusted administrators with the `system.frosh_adminer` ACL permission have access.
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, use [GitHub's private vulnerability reporting](https://github.com/FriendsOfShopware/FroshPlatformAdminer/security/advisories/new).
+
+### What to include
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Affected version(s)
+- Any potential fix or mitigation you have identified
+
+### What to expect
+
+- We review reported security issues as quickly as possible.
+- A security advisory will be published on GitHub after the fix is released.
+- You will be credited in the advisory (unless you prefer anonymity).


### PR DESCRIPTION
Adds SECURITY.md with vulnerability reporting guidelines and a notice that this plugin is intended for development environments only.