### PR TITLE
Update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build:
-    uses: FriendsOfShopware/actions/.github/workflows/store-shopware-cli.yml@main
+    uses: shopware/github-actions/.github/workflows/store-release.yml@main
     with:
       extensionName: ${{ github.event.repository.name }}
     secrets:
-      accountUser: ${{ secrets.ACCOUNT_USER }}
-      accountPassword: ${{ secrets.ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `accountUser` / `accountPassword` secrets with `clientId` / `clientSecret` (using `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET`)
- Update reusable workflow reference from `FriendsOfShopware/actions/.github/workflows/store-shopware-cli.yml@main` to `shopware/github-actions/.github/workflows/store-release.yml@main`

This aligns the workflow with the updated secret names and the new canonical reusable workflow location.