### PR TITLE
Allow to disable SSL verification

### DIFF
--- a/src/Adminer/adminer-plugins.php
+++ b/src/Adminer/adminer-plugins.php
@@ -6,6 +6,9 @@ $ssl = [
     'ca' => EnvironmentHelper::getVariable('DATABASE_SSL_CA'),
     'cert' => EnvironmentHelper::getVariable('DATABASE_SSL_CERT'),
     'key' => EnvironmentHelper::getVariable('DATABASE_SSL_KEY'),
+    'verify' => EnvironmentHelper::hasVariable('DATABASE_SSL_DONT_VERIFY_SERVER_CERT')
+        ? !EnvironmentHelper::getVariable('DATABASE_SSL_DONT_VERIFY_SERVER_CERT')
+        : null,
 ];
 
 $sslConfig =  0 < count(array_filter($ssl)) ? $ssl : null;


### PR DESCRIPTION
Support DATABASE_SSL_DONT_VERIFY_SERVER_CERT env-variable to disable the verification of SSL certificates.

This is the same variable used by Shopware itself:
https://github.com/shopware/shopware/blob/3fcec7f6822eca11d1d528db5c934eb3fac893c5/src/Core/Framework/Adapter/Database/MySQLFactory.php#L81-L83